### PR TITLE
Support NC code search with dots (e.g., 630790.98.99)

### DIFF
--- a/web/src/pages/Home.jsx
+++ b/web/src/pages/Home.jsx
@@ -266,13 +266,13 @@ function Home() {
       return includeParentsAndChildren(matchedItems)
     }
 
-    // Check if search is numeric (NC code search) - allow spaces in between
-    const searchValueNoSpaces = searchValue.replace(/\s/g, '')
-    const isNumericSearch = /^[0-9]+$/.test(searchValueNoSpaces)
+    // Check if search is numeric (NC code search) - allow spaces and dots in between
+    const searchValueNormalized = searchValue.replace(/[\s.]/g, '')
+    const isNumericSearch = /^[0-9]+$/.test(searchValueNormalized)
 
     if (isNumericSearch) {
-      // Exact match for NC codes (no fuzzy) - remove spaces from input
-      matchedItems = flatData.filter(item => item.nc.includes(searchValueNoSpaces))
+      // Exact match for NC codes (no fuzzy) - remove spaces and dots from input
+      matchedItems = flatData.filter(item => item.nc.includes(searchValueNormalized))
       return includeParentsAndChildren(matchedItems)
     }
 


### PR DESCRIPTION
Dots are now removed from search input along with spaces when searching for NC codes, making it easier to paste codes in dotted format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)